### PR TITLE
[jeongmin] BOJ_연속합

### DIFF
--- a/BOJ/1912.연속합/jeongmin.py
+++ b/BOJ/1912.연속합/jeongmin.py
@@ -1,0 +1,13 @@
+# 23.04.28
+# DP
+
+N = int(input())
+num = list(map(int, input().split()))
+
+answer = num[0]
+dp = num[0]
+for i in range(1, len(num)):
+    dp = max(dp + num[i], num[i])
+    answer = max(dp, answer)
+
+print(answer)


### PR DESCRIPTION
## ✅ 올리기 전 체크리스트

## 🔗 문제 링크
https://www.acmicpc.net/problem/1912

알고리즘 분류 : DP(다이나믹 프로그래밍)
level : 실버 2

## 🔮 풀이 아이디어

n개의 정수로 이루어진 임의의 수열 중 연속된 수들의 합이 가장 큰 경우를 출력해야 한다.

특정 수의 경우의 수는 이전에 연속된 합을 선택하거나 선택하지 않는 경우이다.
선택하는 경우 : 이전 합에 자신의 수를 더한 값
선택하지 않는 경우 : 자신의 수 (이전에 연속된 합을 선택하지 않으면서 현재 숫자가 처음이 된다)

처음에는 더한 모든 경우의 수를 배열에 저장해야 할까 생각했는데 과정을 적어보니 결국 이전 값이 가장 큰 경우에 자신의 수를 더하는 경우가 합이 가장 클 수 밖에 없다. 따라서 그 값만 계속 저장하는 식으로 풀이를 작성했다.

`dp = max(dp + num[i], num[i])`

그리고 answer이라는 변수를 따로 둠으로써 각 숫자의 차례까지의 연속합 중 가장 큰 경우를 저장한다.
이렇게 하지 않으면 문제 예제의 1번의 경우 `12 + 21`에 마지막 숫자의 `-1`이 더해진 값 `32`가 가장 큰 경우로 출력하게 된다.

## 📝 새로 공부한 내용

## 📚 참고
