### PR TITLE
[jeyoon] Programmers_올바른 괄호

### DIFF
--- a/Programmers/올바른_괄호/jeyoon.js
+++ b/Programmers/올바른_괄호/jeyoon.js
@@ -1,0 +1,30 @@
+function solution(s) {
+  let answer = true;
+  // let stack = [];
+  let stackCounter = 0;
+  const stringArr = s.split("");
+
+  stringArr.every((c) => {
+    // 여는 괄호일 경우 -> 스택에 넣어둔다.
+    if (c === "(") {
+      // stack.push(c);
+      stackCounter++;
+      return true;
+    }
+    // 닫는 괄호일 경우 -> 열려 있는 괄호가 없는 경우 -> 올바른 괄호가 아님
+    if (stackCounter == 0) {
+      answer = false;
+      return false;
+    }
+    // 닫는 괄호인 경우 -> 열려 있는 괄호가 있는 경우 -> 닫아주고 스택에서 뺀다.
+    stackCounter--;
+    return true;
+  });
+
+  // 닫히지 않은 괄호가 남아있는 경우
+  if (stackCounter != 0) {
+    answer = false;
+  }
+
+  return answer;
+}


### PR DESCRIPTION
## ✅ 올리기 전 체크리스트

<!-- 추후 추가 예정 -->

## 🔗 문제 링크

https://school.programmers.co.kr/learn/courses/30/lessons/12909

'(' 또는 ')' 로만 이루어진 문자열 `s`가 주어졌을 때, 문자열 s가 올바른 괄호이면 `true`를 return 하고, 올바르지 않은 괄호이면 `false`를 return 하는 `solution` 함수를 완성하는 문제입니다.

## 🔮 풀이 아이디어

닫는 괄호는 가장 가까운 여는 괄호랑 쌍을 이뤄야 한다는 점을 이용하여, 여는 괄호인 경우에는 Stack에 쌓아두고, 닫는 괄호인 경우에는 Stack의 `top`에 있는 여는 괄호랑 짝을 지어 Stack에서 `pop`하는 방법을 이용했습니다.

Javascript에는 기본적으로 Stack이 없기 때문에 일반 배열을 이용해서 `push`, `pop` 연산을 수행해줬었는데요. 시간초과 문제 때문에 이리저리 고민하다 해당 문제의 조건(주어지는 문자열은 '('과 ')'으로만 이루어져 있다)하에서는 Stack에 무조건 '('만 들어가기 때문에 실제로 스택에 넣어주는 작업은 불필요하다는 것을 깨달았습니다. (하지만 아래에 나오겠지만 시간초과의 원인은 다른 곳에 있었어서, 배열로 풀어도 시간초과가 나지 않을 수도 있습니다.)

따라서 배열을 이용하여 실제로 스택의 내용물을 관리해 주는 대신, 스택에 들어가는 '('의 개수를 이용하여 (`stackCounter`) 현재 스택에 내용물이 있는지, 비어있는지를 확인해주었습니다. (그 안에 내용물은 확인하지 않아도 무조건 '('))

올바른 괄호, 즉 괄호가 잘 짝지어졌다는 것은 '('과 ')'의 순서가 잘 맞고, 개수가 동일하다는 것이기 때문에 ')'(닫는 괄호)가 등장했을 때 짝지을 수 있는 여는 괄호가 없거나, 닫는 괄호로 모두 짝지어줬는데도 스택에 여는 괄호가 남아있는 경우를 올바르지 않은 괄호로 판단해주고, 그 외의 경우에는 올바른 괄호로 판단해주었습니다.

## 📝 새로 공부한 내용

위에서 시간초과 문제로 실제 배열로 다루는 방식에서 스택에 담겨있는 내용물의 개수를 관리하는 방식으로 바꾸었다고 했었는데, 실제로 시간초과가 발생하던 원인은 다른 곳에 있었습니다.

스택이 비었거나, 비지 않았음을 확인하기 위해서 일치 연산자 (`===`)를 사용했었을 때에는 시간초과가 발생했었는데, 비교 연산자를 동등 연산자 (`==`)로 바꿔주었을때는 시간초과가 발생하지 않았습니다 (!!)

```js
// 시간초과
if (stackCounter === 0) {
 answer = false;
 return false;
}
// 시간초과 x (효율성 테스트 통과)
if (stackCounter == 0) {
 answer = false;
 return false;
}
```

동등 연산자는 단순히 '값'만 비교하는 것에 비해서 일치 연산자는 타입 또한 비교하기 때문에 막연히 시간이 좀 더 걸릴 것이라고 생각하긴 했지만 실제로 이렇게 유의미한 차이가 난다는 것은 새롭게 알게 되었습니다... (하지만 대부분의 경우에서는 일치 연산자로 타입까지 확인해주는 것이 좋음.)

## 📚 참고

<!-- 문제를 풀면서 참고했던 링크가 있다면 추가해주세요 -->
