### PR TITLE
[jeongmin] BOJ_부등호

### DIFF
--- a/BOJ/2529.부등호/jeongmin.py
+++ b/BOJ/2529.부등호/jeongmin.py
@@ -1,0 +1,46 @@
+# a [symbol] b 에 대한 식이 맞는지 확인
+def is_correct(a, b, symbol):
+    if symbol == '<':
+        return a < b
+    return a > b
+
+
+def brute_force(cnt, result):
+    # 함수 내에서 전역변수 참조 및 수정
+    global N, symbol, answer, choose
+
+    # 재귀 종료 조건
+    if N == cnt: 
+        if answer is None: # max값이라면 출력
+            print(''.join(map(str, result)))
+        answer = ''.join(map(str, result))
+        return
+
+    # 가장 큰 수인 9부터 0까지 값을 차례대로 대입해보기
+    for i in reversed(range(10)):
+        # 이미 사용된 값인지 확인
+        if choose[i] is True:
+            continue
+        # 식을 만족하는지 확인(비교할 숫자가 없는 경우는 제외)
+        if result and is_correct(result[-1], i, symbol[cnt]) is False:
+            continue
+        
+        # 값 선택
+        result.append(i)
+        choose[i] = True
+        
+        # 재귀
+        brute_force(cnt + 1, choose, result)
+        
+        # 이후 재사용하는 값들 원상복구
+        result.pop()
+        choose[i] = False
+
+
+
+N = int(input())
+symbol = input().split()
+choose = [False] * 10 # index에 해당하는 수를 사용했는지 확인하는 배열
+answer = None         # min 값을 담아줄 변수
+brute_force(-1, choose, [])
+print(answer)


### PR DESCRIPTION
## ✅ 올리기 전 체크리스트

<!-- 추후 추가 예정 -->

## 🔗 문제 링크

https://www.acmicpc.net/problem/2529
제시된 k개의 부등호 순서를 만족하는 (k + 1)자리의 정수 중에서 최댓값과 최솟값을 찾아야 한다.
각 부등호의 앞뒤에 들어가는 숫자는 `{ 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 }` 중에서 선택해야 하며 선택된 숫자는 모두 달라야 한다. 

## 🔮 풀이 아이디어

각 부등호를 만족하는 모든 경우의 수를 구하여 풀 수 있는 문제라고 생각했습니다.
따라서 `permutation` 함수를 활용한 코드를 생각할 수 있었지만, 
부등호가 앞에서 이미 맞지 않아도 뒤의 경우의 수를 구해준다는 단점이 존재해 시간이 오래 걸릴 것 같았어요.
이후 직접 작성해 제출해보니 실제로 더 오래걸리는 것을 확인했습니다!

따라서 재귀를 활용하는 Brute Force 알고리즘으로 작성했습니다.

`brute_force` 함수 맨 처음에 `global`로 선언해준 변수들은 함수 안에서 새로운 지역변수가 아닌 함수 밖에서 이미 선언된 전역 변수를 가리키게 됩니다.

9부터 0까지 값을 차례대로 넣으면서 부등식이 성립하는지 확인하는 `is_correct`를 통해 만족하는 값을 넣어가며 경우의 수를 모두 확인합니다.
`choose`라는 배열을 통해 값을 선택했는지에 대한 여부를 확인합니다.

만약  `N(부등호의 수) + 1`만큼 숫자를 모두 선택할 경우 재귀 종료 조건으로 `answer`에 값을 대입합니다.
- `''.join(map(str, result)` : 리스트에 담겨있는 정수를 map 함수를 통해 문자열로 변경한 수 각 값을 합쳐 새로운 문자열로 만들어줍니다.
- 9부터 0까지 차례대로 넣어주기 때문에 가장 처음에 만족하는 answer은 max 값을 의미합니다. 따라서 바로 출력해줍니다. 그리고 제일 늦게 만족하는 answer이 min 값이 됩니다.

값을 선택하고 재귀함수를 다시 호출하고 나서 돌아올 때 이후의 다른 경우를 확인해야 하기 때문에 재사용하는 배열들(`result`, `choose`)를 원상복구합니다.

## 📝 새로 공부한 내용

max 값, min값을 따로 구하도록 작성하신 다른 분의 풀이도 보았습니다.
9부터 0까지 넣어보다가 만족하는 경우의 수 max를 구하고 함수를 종료한 후, 다시 0부터 9까지 넣어보면서 만족하는 경우의 수 min을 구하는 방식이었습니다.

이렇게 하면 불필요한 경우 확인이 필요 없어 시간을 단축시킬 수 있습니다.

## 📚 참고

https://www.daleseo.com/python-global-nonlocal/
