### PR TITLE
[eunbikim] Programmers_숫자 문자열과 영단어

### DIFF
--- a/Programmers/숫자_문자열과_영단어/eunbikim.cpp
+++ b/Programmers/숫자_문자열과_영단어/eunbikim.cpp
@@ -1,0 +1,29 @@
+#include <string>
+#include <vector>
+
+using namespace std;
+
+vector<string> getEngArr() {
+    vector<string> eng;
+    eng.push_back("zero");
+    eng.push_back("one");
+    eng.push_back("two");
+    eng.push_back("three");
+    eng.push_back("four");
+    eng.push_back("five");
+    eng.push_back("six");
+    eng.push_back("seven");
+    eng.push_back("eight");
+    eng.push_back("nine");
+    return eng;
+}
+
+int solution(string s) {
+    // vector<string> eng = {"zero", "one", ... , "nine"}; 로 하는 게 훨씬 나았을 듯..
+    vector<string> eng = getEngArr();
+    for (int i = 0; i < eng.size(); i++) {
+        while (s.find(eng[i]) != string::npos)
+            s.replace(s.find(eng[i]), eng[i].length(), to_string(i));
+    }
+    return stol(s);
+}


### PR DESCRIPTION
## ✅ 올리기 전 체크리스트

<!-- 추후 추가 예정 -->

## 🔗 문제 링크
https://school.programmers.co.kr/learn/courses/30/lessons/81301
<!-- 문제 링크 -->
<!-- 필요하다면 문제에 대한 간단한 설명도 해 주기-->
네오와 프로도가 숫자놀이를 하고 있습니다. 네오가 프로도에게 숫자를 건넬 때 일부 자릿수를 영단어로 바꾼 카드를 건네주면 프로도는 원래 숫자를 찾는 게임입니다.

다음은 숫자의 일부 자릿수를 영단어로 바꾸는 예시입니다.

1478 → "one4seveneight"
234567 → "23four5six7"
10203 → "1zerotwozero3"

"1zerotwozero3"와 같은 문자열을 받아 10203이라는 정수를 반환해야 합니다!
## 🔮 풀이 아이디어
우선 `0`부터 `9`까지의 숫자가 `zero` ~ `nine`으로 치환될 수 있으므로, 해당 값을 저장하는 배열을 만들어줬습니다. 선언하면서 바로 값을 할당해주는 게 훨씬 깔끔했을 것 같은데 아무 생각없이 `push_back`으로 값을 넣어줬습니다..

문자열에서 어떤 특정 문자열을 찾아 값을 치환한다 < 라고 문제를 접근했기 때문에 저는 string의 내장 함수인 `find`와 `replace`를 사용했습니다.

`find`를 통해 특정 문자열(ex. "zero")이 문자열에 존재하는지 확인하고, 존재한다면 `replace`를 통해 그 인덱스로부터 문자열의 길이만큼을 숫자로 치환해줬습니다.

처음에는 특정 문자열이 중복되어 나오는 경우(ex. zero12zero)를 고려하지 않고 문제를 풀어서 실패하는 테스트 케이스가 있었습니다.
그래서 `while 문`을 통해 `find`의 값이 `npos`가 아닐 동안 모든 값을 치환할 수 있도록 수정했습니다 :-]

<!-- 문제 접근 방식, 구현 과정 등에 대해서 정리해주세요 -->

## 📝 새로 공부한 내용
### stol
- string to long
- stoi(string to i), stod(string to double) 등 다양하게 존재.. 
### find
- string 내장 함수
- `string.find(찾을 문자열)`에서 찾을 문자열이 존재하면 `시작 인덱스 값`을, 없다면 `string::npos` 값을 반환합니다.
- `string.find(찾을 문자열, 찾기 시작할 인덱스)`와 같은 방식으로도 사용할 수 있습니다.
### replace
- string 내장 함수
- `string.replace(치환할 부분 시작 위치, 치환할 부분 길이, 바뀔 문자열)`

다른 분들의 풀이를 보면서 알게 된 함수입니다!
### regex_replace
- <regex> 헤더에 존재
- `regex_replace.(대상 문자열, regex(정규식), 치환 문자열)`
-  정규식에 일치하는 부분은 모두 치환
- 원래 제 코드에서 `while 문`을 제외하고
`s = regex_replace(s, regex(eng[i]), to_string(i));`
를 활용하는 방법도 있었을 것 같습니다! 

<!-- 문제를 풀면서 새로 알게된 알고리즘이라던가, 함수 등이 있다면 정리해주세요 -->

## 📚 참고
https://xaida.tistory.com/12
<!-- 문제를 풀면서 참고했던 링크가 있다면 추가해주세요 -->
