### PR TITLE
[jeongmin] BOJ_완전 이진 트리

### DIFF
--- a/BOJ/9934.완전_이진_트리/jeongmin.py
+++ b/BOJ/9934.완전_이진_트리/jeongmin.py
@@ -1,0 +1,23 @@
+from collections import deque
+
+
+def levelorder(K, num):
+    print_height = K
+    queue = deque([(K, num)])
+    while queue:
+        height, tree = queue.popleft()
+        if not tree:
+            continue
+        if print_height != height:
+            print_height = height
+            print()
+        root = (2 ** height - 2) // 2
+        print(tree[root], end=' ')
+        if height != 1:
+            queue.append((height - 1, tree[:root]))
+            queue.append((height - 1, tree[root + 1:]))
+
+
+K = int(input())
+num = list(map(int, input().split()))
+levelorder(K, num)


### PR DESCRIPTION
## ✅ 올리기 전 체크리스트

<!-- 추후 추가 예정 -->

## 🔗 문제 링크

https://www.acmicpc.net/problem/9934

문제 설명이 굉장히 긴데 요약하자면
완전 이진 트리의 깊이 `K`와 `inorder`(왼쪽 자식 -> 부모 -> 오른쪽 자식)로 방문된 트리 순서 값을 입력 받아 
`levelorder`(한 레벨이 모든 노드를 방문하고 다음 레벨로 방문) 순서로 출력하면 됩니다.

<img width="1391" alt="스크린샷 2023-05-26 오후 6 49 41" src="https://github.com/women-in-42-study/Algorithm/assets/44529556/e7941e4d-be57-4a69-ad89-ead87b26f5ca">

## 🔮 풀이 아이디어

완전 이진 트리는 이진 트리 구조로 되어있고, Leaf 노드를 제외한 모든 부모 노드가 자식 노드를 2개씩 가지고 있다는 특징이 있습니다. 
완전 이진 트리는 마지막 level에 위치한 노드가 없는 경우도 있지만, 문제에서는 `깊이가 K인 완전 이진 트리는 총 2**K-1개의 노드로 이루어져 있다.`라고 되어있기 때문에 포화 이진 트리라고 생각할 수 있습니다.

> 완전 이진 트리 : 포화 이진 트리의 leaf들을 오른쪽에서부터 제거하여 얻어진 트리
> 포화 이진 트리 : 모든 잎의 레벨이 동일한 이진 트리이며, 잎이 아닌 내부 노드들은 모두 2개의 자식을 가지는 트리

문제에서 트리의 높이(깊이)를 입력으로 주기 때문에 `inorder`로 방문된 트리 순서 값에서 아래의 식으로 루트 노드의 위치를 구할 수 있습니다.
`root = (2**height - 2) // 2`

만약 높이(깊이)가 `3`인 경우 최대 `2**height - 1`개의 노드를 가질 수 있고, 
여기서 루트 노드 1개를 제외하고 2로 나누면 루트 노드 기준 왼쪽 자식 서브 트리의 노드 개수를 구할 수 있습니다.
여기서는 인덱스 기준(0부터 시작)이기 때문에 서브 트리의 노드 개수가 루트 노드의 인덱스 값이 됩니다.

큐를 활용하여 마지막 Leaf 노드가 아닌 경우(`height != 1`) 
루트 노드의 왼쪽 자식 서브 트리, 오른쪽 자식 서브 트리를 큐에 삽입해 `levelorder`로 탐색을 진행해주었습니다.

문제를 풀 때는 포화 이진트리의 경우만 받는다고 생각하지 못해서 마지막에 위치한 Leaf 노드는 자식 노드가 없을 때에 대한 예외처리를 추가해주었습니다. 하지만 이 문제에서는 필요가 없다는 것을 나중에 깨달았습니다..🥲

그리고 `level`마다 출력 후에 개행 문자가 출력되어야 하기 때문에 `print_height`라는 변수를 이용해 확인해주었습니다.

여기서는 서브트리의 배열을 계속 새로 만들어서 queue에 함께 추가해주었는데,
시작 인덱스와 끝 인덱스 등 인덱스를 활용하는 방식이면 조금 더 시간이 줄어들지 않을까..? 싶습니다!

## 📝 새로 공부한 내용

<!-- 문제를 풀면서 새로 알게된 알고리즘이라던가, 함수 등이 있다면 정리해주세요 -->

## 📚 참고

[완전 이진 트리](https://enlqn1010.tistory.com/18)
[완전이진트리 vs 포화이진트리 : 이 둘에 대해 알아봅시다.](https://codingdog.tistory.com/entry/%EC%99%84%EC%A0%84%EC%9D%B4%EC%A7%84%ED%8A%B8%EB%A6%AC-vs-%ED%8F%AC%ED%99%94%EC%9D%B4%EC%A7%84%ED%8A%B8%EB%A6%AC-%EC%9D%B4-%EB%91%98%EC%97%90-%EB%8C%80%ED%95%B4-%EC%95%8C%EC%95%84%EB%B4%85%EC%8B%9C%EB%8B%A4)
[트리 순회 알고리즘#02 중위 순회(Inorder Traversal)](https://codingstarter.tistory.com/7)
[트리 순회 알고리즘#04 레벨 순회(Level Order Traversal)](https://codingstarter.tistory.com/9)
