### PR TITLE
[jeongmin] BOJ_ 폴리오미노

### DIFF
--- a/BOJ/1343.폴리오미노/jeongmin.py
+++ b/BOJ/1343.폴리오미노/jeongmin.py
@@ -1,0 +1,10 @@
+board = input().split(".")
+
+for i, piece in enumerate(board):
+    cnt = piece.count('X')
+    if cnt % 2 == 1:
+        board = ["-1"]
+        break
+    board[i] = "AAAA" * (cnt // 4) + "BB" * (cnt % 4 // 2)
+
+print('.'.join(board))


### PR DESCRIPTION
## ✅ 올리기 전 체크리스트

<!-- 추후 추가 예정 -->

## 🔗 문제 링크

https://www.acmicpc.net/problem/1343

문제 설명: 
민식이는 다음과 같은 폴리오미노 2개를 무한개만큼 가지고 있다. `AAAA`와 `BB`
`.`와 `X`로 이루어진 보드판이 주어졌을 때, `X`를 모두 폴리오미노로 덮으려고 한다. 이때, `.`는 폴리오미노로 덮으면 안 된다.
폴리오미노로 모두 덮은 보드판(사전 순으로 가장 앞서는 답)을 출력하는 프로그램을 작성하시오. 만약 덮을 수 없으면 -1을 출력한다.

## 🔮 풀이 아이디어

보드판에서 X만 채워넣을 수 있기 때문에 . 기준으로 `split` 후 나중에 다시 `join()` 함수를 통해 `.`을 기준으로 문자열로 합쳐줍니다.

`AAAA`가 `BB`보다 사전 순으로 앞서기 때문에 `X`가 연속으로 4개가 만들어 질 수 있다면 무조건 `AAAA`를 채워 넣고 이후 남은 값을 `BB`를 채워넣습니다.

하지만 `X`가 홀수개라면 폴리오미노로 덮을 수 없기 때문에 -1을 보드에 담아 출력해주었습니다.

`enumerate` 함수는 파이썬의 내장 함수로 인덱스와 원소로 이루어진 튜플을 만들어줍니다. 
여기서는 원래 문자열에서 폴리오미노로 만들어진 문자열로 교체할 때 인덱스가 필요해서 사용하였습니다.

## 📝 새로 공부한 내용

[다른 분의 풀이](https://www.acmicpc.net/source/54911938)를 보고 간단하게 이해하기 쉬운 코드로 짤 수 있다는 것을 알게 되었습니다..!

`XXXX`를 먼저 `AAAA`로 바꿔준 후, `XX`를 `BB`로 바꿉니다.
이렇게 했을 때 `X`가 남아있다면 -1, 아니면 값을 출력하는 방식입니다.

`replace` 함수를 알고 있었는데 생각하지 못한 풀이라 보고  와..! 싶었답니다 😂

```python
b = input()

pan = ['AAAA','BB']
board = b.replace('XXXX', pan[0])
board = board.replace('XX', pan[1])

if 'X' in board:
    print(-1)
else:
    print(board)
``` 

## 📚 참고

[파이썬의 enumerate() 내장 함수로 for 루프 돌리기](https://www.daleseo.com/python-enumerate/)
