### PR TITLE
[jeongmin] BOJ_회의실 배정

### DIFF
--- a/BOJ/1931.회의실_배정/jeongmin.py
+++ b/BOJ/1931.회의실_배정/jeongmin.py
@@ -1,0 +1,16 @@
+import sys
+input = sys.stdin.readline
+
+N = int(input())
+time = sorted([tuple(map(int, input().split())) for _ in range(N)])
+cnt = 0
+available = 0
+
+for start, end in time:
+    if available <= start:
+        cnt += 1
+        available = end
+    elif end < available:
+        available = end
+
+print(cnt)


### PR DESCRIPTION
<!--

✅ 올리기 전 체크리스트

✔️ 한 문제에 대한 commit들만 올려져 있나요? (문제 별로 다른 PR을 올려주세요 ^_^)
✔️ 폴더 경로 확인! (문제사이트/문제이름(번호.문제명 OR 문제명(띄어쓰기는 모두 _로 치환)))
✔️ Assignees 추가했나요? (본인으로 추가!)
✔️ Label 추가했나요? (문제 사이트, 푼 언어)
✔️ 수고하셨습니다~!🥳

-->

## 🔗 문제 링크

https://www.acmicpc.net/problem/1931

한 개의 회의실을 사용하고자 하는 `N`개의 회의에 대하여 회의실 사용표를 만들려고 한다.
단 회의는 한번 시작하면 중단될 수 없으며, 한 회의가 끝나는 것과 동시에 다음 회의가 시작될 수 있다.
각 회의에 대해 시작 시간과 끝나는 시간이 주어지고, 각 회의가 겹치지 않게 하면서 회의실을 사용할 수 있는 회의의 최대 개수를 찾아보자.

## 🔮 풀이 아이디어

처음에 문제를 보았을 때 dp인가..? 생각해보다가 시작 시간과 끝나는 시간이 `0 ~ 2147483647` 범위로 받을 수 있는 것을 보고 이건 아닌 것 같다.. 싶었습니다 ㅠㅠ
도저히 어떻게 풀 지 감이 잡히지 않아서 알고리즘 분류를 확인해보니 **그리디 알고리즘**이더라구요..!
이걸 보고도 바로 아! 하고 풀리지는 않았습니다.. 계속 생각하다 겨우 풀 수 있었습니다 🥲
그리디는 정말 생각하기 어려운 것 같습니다 ㅠㅠ..

> [그리디 알고리즘](https://namu.wiki/w/%EA%B7%B8%EB%A6%AC%EB%94%94%20%EC%95%8C%EA%B3%A0%EB%A6%AC%EC%A6%98)(욕심쟁이 알고리즘, Greedy Algorithm)
> : "매 선택에서 지금 이 순간 당장 최적인 답을 선택하여 적합한 결과를 도출하자"라는 모토를 가지는 알고리즘 설계 기법

어떤 회의을 선택해야 사용가능한 회의의 최대 개수를 구할 수 있을까? 생각을 하다가 아래의 순서대로 규칙을 확장할 수 있었습니다.
아래 정보는 `(시작 시간, 끝나는 시간)` 으로 설명해두었습니다.
1. `(1, 3)`, `(1, 4)`인 경우 `(1, 3)`이 더 좋습니다. 회의가 빨리 끝나면 회의실이 빨리 공실이 됩니다.
2. 마찬가지로 `(2, 3)`, `(1, 4)`인 경우 `(2, 3)`이 더 좋습니다.
3. 그러면 `(2, 4)`, `(3, 5)`인 경우는 뭐가 더 좋은 경우인가? 보았을 때 `(2, 4)`가 더 좋습니다. 회의실은 공실이 아니라면 빨리 끝나는 경우가 더 좋습니다.
(3번 규칙을 늦게 깨달아 풀이를 떠올리는 시간이 오래 걸린 것 같습니다 ㅠㅠ)

**결론: 회의실이 공실이 되는 시점의 시간이 빠를수록 좋은 선택이다!**

위의 규칙을 바탕으로 코드를 작성하였습니다.
먼저 회의 정보를 정렬해서 `time`이라는 리스트에 튜플 형태인 `(시작 시간, 끝나는 시간)`로 담아주었습니다.
정렬을 하게 되면 먼저 회의실을 쓰는 경우 순서대로 탐색이 가능합니다.

그리고 회의실이 공실이 되는 시간이 회의 시작시간보다 작거나 같다면 회의를 시작할 수 있기 때문에 카운트를 1 증가시킵니다.
만약 위의 경우를 만족하지 않고 회의 끝나는 시간이 공실이 되는 시간보다 작을 경우는 더 좋은 선택이기 때문에 공실이 되는 시간을 현재 회의가 끝나는 시간으로 변경시켜줍니다. 
어짜피 이전에 카운트는 증가되었고, 이전 선택 대신 현재 회의로 변경하겠다는 의미로 카운트는 변경되지 않습니다.



## 📝 새로 공부한 내용

<!-- 문제를 풀면서 새로 알게된 알고리즘이라던가, 함수 등이 있다면 정리해주세요 -->

## 📚 참고

<!-- 문제를 풀면서 참고했던 링크가 있다면 추가해주세요 -->
