### PR TITLE
[eunbikim] Programmers_실패율

### DIFF
--- a/Programmers/실패율/eunbikim.cpp
+++ b/Programmers/실패율/eunbikim.cpp
@@ -1,0 +1,22 @@
+#include <string>
+#include <vector>
+#include <map>
+
+using namespace std;
+
+vector<int> solution(int N, vector<int> stages) {
+    vector<int> answer;
+    vector<int> stop(N + 2, 0);
+    vector<int> reach(N + 2, 0);
+    multimap<double, int, greater<double>> ratio;
+    for (auto i : stages) {
+        for (int j = 1; j <= i; j++)
+            reach[j]++;
+        stop[i]++;
+    }
+    for (int i = 1; i <= N; i++)
+        ratio.insert({stop[i] / (double)reach[i], i});
+    for (auto stage : ratio)
+        answer.push_back(stage.second);
+    return answer;
+}


### PR DESCRIPTION
<!--

✅ 올리기 전 체크리스트

✔️ 한 문제에 대한 commit들만 올려져 있나요? (문제 별로 다른 PR을 올려주세요 ^_^)
✔️ 폴더 경로 확인! (문제사이트/문제이름(번호.문제명 OR 문제명(띄어쓰기는 모두 _로 치환)))
✔️ Assignees 추가했나요? (본인으로 추가!)
✔️ Label 추가했나요? (문제 사이트, 푼 언어)
✔️ 수고하셨습니다~!🥳

-->

## 🔗 문제 링크
https://school.programmers.co.kr/learn/courses/30/lessons/42889
<!-- 문제 링크 -->
<!-- 필요하다면 문제에 대한 간단한 설명도 해 주기-->
실패율은 `스테이지에 도달했으나 아직 클리어하지 못한 플레이어의 수 / 스테이지에 도달한 플레이어 수`로 구할 수 있습니다.
최대 `N`까지의 스테이지가 있으며, `stages` 배열에는 아직 클리어하지 못한 스테이지 번호가 들어있다. 번호가 `N + 1`인 경우는 모든 스테이지를 성공했을 때 입니다.
## 🔮 풀이 아이디어
쉬운 문제인 줄 알았으나 직접 구현하려고 보니 헷갈리는 부분들이 있어 차근차근 생각해보고 구현했습니다.

우선 두 가지의 정보가 필요하기 때문에 2개의 배열을 생성했습니다.
- 스테이지에 도달했으나 아직 클리어하지 못한 플레이어의 수 : `stop`
- 스테이지에 도달한 플레이어 수 : `reach`

`stages` 배열에 들어오는 값은 이용자가 현재 멈춰있는 스테이지의 번호라고 했기 때문에, 멈춰있는 번호까지의 스테이지는 도달했다고 생각하여 반복문으로 방문자(`reach[i]`의 값)를 증가시켜 줬습니다. 동시에 멈춰있는 사람의 수(`stop[i]`의 값)도 증가 시켜줬습니다.
<!-- 문제 접근 방식, 구현 과정 등에 대해서 정리해주세요 -->

`실패율`을 내림차순으로 정렬하여 `스테이지 번호`를 반환해야해서 `multimap` 이라는 자료구조를 사용했습니다. key 중복을 허용하는 `map`입니다. `map`은 key로 정렬이 되기 때문에 key를 `실패율`로, value를 `스테이지 번호`로 설정해줬습니다.

그 후 `multimap`에 정렬되어 저장된 값을 `vector`로 옮겨서 반환해줬습니다!
## 📝 새로 공부한 내용
### multimap
- <map> 헤더에 포함
- 중복된 key 값을 허용
- 나머지는 `map`과 같음
<!-- 문제를 풀면서 새로 알게된 알고리즘이라던가, 함수 등이 있다면 정리해주세요 -->

## 📚 참고

<!-- 문제를 풀면서 참고했던 링크가 있다면 추가해주세요 -->
