### PR TITLE
[jeongmin] BOJ_로프

### DIFF
--- a/BOJ/2217.로프/jeongmin.py
+++ b/BOJ/2217.로프/jeongmin.py
@@ -1,0 +1,11 @@
+import sys
+input = sys.stdin.readline
+
+N = int(input())
+weight = sorted([int(input()) for i in range(N)], reverse=True)
+ans = weight[0]
+
+for i in range(1, N):
+    ans = max(ans, weight[i] * (i + 1))
+
+print(ans)


### PR DESCRIPTION
<!--

✅ 올리기 전 체크리스트

✔️ 한 문제에 대한 commit들만 올려져 있나요? (문제 별로 다른 PR을 올려주세요 ^_^)
✔️ 폴더 경로 확인! (문제사이트/문제이름(번호.문제명 OR 문제명(띄어쓰기는 모두 _로 치환)))
✔️ Assignees 추가했나요? (본인으로 추가!)
✔️ Label 추가했나요? (문제 사이트, 푼 언어)
✔️ 수고하셨습니다~!🥳

-->

## 🔗 문제 링크

https://www.acmicpc.net/problem/2217

`N`개의 로프가 있다. 각각의 로프는 들 수 있는 물체의 중량이 서로 다를 수 있다.
하지만 여러 개의 로프를 병렬로 연결하면 각각의 로프에 걸리는 중량을 나눌 수 있다. `k`개의 로프를 사용하여 중량이 `w`인 물체를 들어올릴 때, 각각의 로프에는 모두 고르게 `w/k` 만큼의 중량이 걸리게 된다.
각 로프들에 대한 정보가 주어졌을 때, 이 로프들을 이용하여 들어올릴 수 있는 물체의 최대 중량을 구해내는 프로그램을 작성하시오.
모든 로프를 사용해야 할 필요는 없으며, 임의로 몇 개의 로프를 골라서 사용해도 된다.

## 🔮 풀이 아이디어

처음에 읽을 때는 간단해 보였는데 문제를 이해하는 데 생각보다 오래걸렸습니다..!

만약 각각 10, 15의 중량을 들어올릴 수 있는 로프가 2개 있다면 최대 중량은 20입니다.
24의 물체를 든다고 한다면 24/2 = 12만큼 각 로프에 중량이 걸리게 됩니다. 
하지만 중량 10의 로프는 12를 들어올릴 수 없습니다.
따라서 10과 15중 더 작은 10 * 2 = 20이 최대 중량이 됩니다.

만약 각각 1, 5, 9의 중량을 들어올릴 수 있는 로프가 3개 있다면 최대 중량은 10입니다.
가능한 경우의 수는 `1(1), 5(5), 9(9), 2(1, 5), 2(1, 9), 10(5, 9), 3(1, 5, 9)` 입니다.
따라서 5와 9의 로프를 고른 것이 최대 중량이 됩니다.

여기서 하나의 로프만 고른다고 하면 1, 5, 9 중에는 9를, 두 로프만 고른다고 하면 5, 9를 선택하는 것이 더 좋습니다. 무조건 로프 중에서 높은 중량을 가진 것들을 선택하면 됩니다. (그리디!)
이를 이용해 문제를 해결하였습니다.

입력받은 중량을 내림차순으로 정렬하여 반복문을 통해 로프를 선택하는 개수를 늘리면서 최대 중량을 구해주었습니다.

## 📝 새로 공부한 내용

<!-- 문제를 풀면서 새로 알게된 알고리즘이라던가, 함수 등이 있다면 정리해주세요 -->

## 📚 참고

<!-- 문제를 풀면서 참고했던 링크가 있다면 추가해주세요 -->