### PR TITLE
[jeongmin] BOJ_더 흔한 타일 색칠 문제

### DIFF
--- a/BOJ/28298.더_흔한_타일_색칠_문제/jeongmin.py
+++ b/BOJ/28298.더_흔한_타일_색칠_문제/jeongmin.py
@@ -1,0 +1,23 @@
+import sys
+input = sys.stdin.readline
+from collections import Counter
+
+N, M, K = map(int, input().split())
+pieces = [[[] for _ in range(K)] for _ in range(K)]
+
+for i in range(N):
+    tile_row = input().rstrip()
+    for j in range(M):
+        pieces[i % K][j % K].append(tile_row[j])
+
+total = N * M
+result = [[0] * K for _ in range(K)]
+for i in range(K):
+    for j in range(K):
+        ch, cnt = Counter(pieces[i][j]).most_common()[0]
+        result[i][j] = ch
+        total -= cnt
+
+print(total)
+for i in range(N):
+    print(''.join(result[i % K]) * (M // K))


### PR DESCRIPTION
<!--

✅ 올리기 전 체크리스트

✔️ 한 문제에 대한 commit들만 올려져 있나요? (문제 별로 다른 PR을 올려주세요 ^_^)
✔️ 폴더 경로 확인! (문제사이트/문제이름(번호.문제명 OR 문제명(띄어쓰기는 모두 _로 치환)))
✔️ Assignees 추가했나요? (본인으로 추가!)
✔️ Label 추가했나요? (문제 사이트, 푼 언어)
✔️ 수고하셨습니다~!🥳

-->

## 🔗 문제 링크

[28298](https://www.acmicpc.net/problem/28298)
`N * M` 크기의 타일이 있다. 타일의 색상은 하나의 알파벳 대문자로 표현된다.
주어진 타일을 `K * K` 크기의 작은 타일로 겹치지 않게 나눴을 때, 나눠진 타일의 색상 배치가 전부 동일하도록 타일의 일부 칸을 골라 다시 색칠하고자 한다.
**최소 몇 개의 칸**을 다시 색칠해야 하는지 구하고, 이를 만족하는 타일의 색상 배치를 **아무거나 하나** 출력하라.
`N`, `M` 은 `K`의 배수이다.

## 🔮 풀이 아이디어

`N * M` 크기의 타일을 `K * K` 타일로 쪼개어서 각 타일에서 어떤 칸에 어떤 색깔로 색칠을 해주어야 할 지 결정해주어야 한다고 생각했습니다.
따라서 다음과 같은 단계로 코드를 작성했습니다.
1. 타일의 정보를 입력받는 동시에 각 타일을 `K * K` 타일로 쪼개졌을 때의 위치에 맞게 배열(`pieces`)에 색상을 추가합니다.
2. `K * K` 타일의 각 위치의 후보 색상들 중 가장 많이 칠해진 색상을 `Counter` 모듈을 활용하여 구해줍니다. 이 때 딕셔너리 형태로 반환되기 때문에 `ch`, `cnt`로 각각 가장 많이 칠해진 색상 문자, 색상 문자 개수를 담아주었습니다.
3. 가장 많이 칠해진 색상으로 해당하는 위치의 모든 색상을 변경해야 합니다. 즉, 전체 타일 중 가장 많이 칠해진 색상은 칠하지 않아도 된다고 판단되어 색상 개수만큼을 빼주었습니다.
4. 가장 많이 칠해진 색상으로 만들어진 `K * K` 타일 배열(`result`)을 `N * M` 크기에 맞게 출력해줍니다.

아래와 같이 `N = 4, M = 6, K = 2` 일 때, 각 후보 타일 배열(`pieces`)은 다음과 같이 `2*2` 크기에 맞춰 구해집니다.
```
ABCBAB
BBACCA
BPAZBB
BBAABB
``` 
```python
pieces = [[['A', 'C', 'A', 'B', 'A', 'B'], ['B', 'B', 'B', 'P', 'Z', 'B']], [['B', 'A', 'C', 'B', 'A', 'B'], ['B', 'C', 'A', 'B', 'A', 'B']]]
``` 

만약 후보 타일의 개수가 같은 경우가 생긴다면 값이 여러가지로 나올 수 있어 이 문제는 그 중 가능한 타일로 출력된다면 모두 정답으로 처리되는 서브태스크 문제입니다. 따라서 가능한 타일 중 하나로 값을 출력해주었습니다.

`Counter` 모듈에 관한 설명이 궁금하시다면 #29 를 확인해주세요 :)

## 📝 새로 공부한 내용

<!-- 문제를 풀면서 새로 알게된 알고리즘이라던가, 함수 등이 있다면 정리해주세요 -->

## 📚 참고

<!-- 문제를 풀면서 참고했던 링크가 있다면 추가해주세요 -->
