### PR TITLE
[jeongmin] BOJ_예산

### DIFF
--- a/BOJ/2512.예산/jeongmin.py
+++ b/BOJ/2512.예산/jeongmin.py
@@ -1,0 +1,20 @@
+N = int(input())
+money = list(map(int, input().split()))
+total = int(input())
+
+start, end = 0, max(money)
+result, max_sum = 0, 0
+
+while start <= end:
+    mid = (start + end) // 2
+    mid_sum = sum([i if i < mid else mid for i in money])
+    
+    if total < mid_sum:
+        end = mid - 1
+    else:
+        if max_sum < mid_sum:
+            result = mid
+            max_sum = mid_sum
+        start = mid + 1
+
+print(result)


### PR DESCRIPTION
<!--

✅ 올리기 전 체크리스트

✔️ 한 문제에 대한 commit들만 올려져 있나요? (문제 별로 다른 PR을 올려주세요 ^_^)
✔️ 폴더 경로 확인! (문제사이트/문제이름(번호.문제명 OR 문제명(띄어쓰기는 모두 _로 치환)))
✔️ Assignees 추가했나요? (본인으로 추가!)
✔️ Label 추가했나요? (문제 사이트, 푼 언어)
✔️ 수고하셨습니다~!🥳

-->

## 🔗 문제 링크

[2512](https://www.acmicpc.net/problem/2512)

국가 예산의 총액 이하에서 가능한 한 최대의 총 예산을 다음과 같은 방법으로 배정한다.
1. 모든 요청이 배정될 수 있는 경우에는 요청한 금액을 그대로 배정한다.
2. 모든 요청이 배정될 수 없는 경우에는 특정한 정수 상한액을 계산하여 그 이상인 예산요청에는 모두 상한액을 배정한다. 상한액 이하의 예산요청에 대해서는 요청한 금액을 그대로 배정한다. 

예를 들어, 전체 국가예산이 485이고 4개 지방의 예산요청이 각각 120, 110, 140, 150이라고 하자. 
이 경우, 상한액을 127로 잡으면, 위의 요청들에 대해서 각각 120, 110, 127, 127을 배정하고 그 합이 484로 가능한 최대가 된다. 

예산을 배정하는 프로그램을 작성하시오.

## 🔮 풀이 아이디어

이분 탐색을 연습하고 싶어서 해당 알고리즘을 활용해야하는 문제를 골라 쉽게 해결할 수 있었습니다.

이 문제는 이분 탐색(Binary Search)를 활용한 매개변수 탐색 문제였습니다.

> 이분 탐색: target과 일치한 값을 찾으면, 함수를 종료하고 위치 반환
> 매개 변수 탐색: target과 일치하는 값을 찾아도 함수를 종료하지 않고 더이상 탐색할 배열이 남아있지 않을 때까지 탐색을 계속한다.
> 출처 : 참고 링크

여기서는 상한액을 매개변수로 두어 탐색을 진행하였습니다.
상한액으로 잡은 숫자를 기준으로 얼마의 예산을 배정해야 하는지에 대해 구한 후 그 값이 총액을 넘는다면 상한액으로 사용 불가능합니다.
총액을 넘지 않는다면 예산 배정이 가능하기 때문에 결과값을 비교해 큰 값으로 갱신해줍니다.

따라서 `start = 0, end = max(지방의 예산요청 리스트)`로 둔 후 이분 탐색을 통해 상한액을 구해주었습니다.
(처음에는 `start = min(지방의 예산요청 리스트)` 으로 두고 코드를 실행시켰는데, 가장 작은 값으로 해도 총액을 넘어설 수 있다는 사실을 뒤늦게 깨닫고 수정해주었습니다..!)

## 📝 새로 공부한 내용

<!-- 문제를 풀면서 새로 알게된 알고리즘이라던가, 함수 등이 있다면 정리해주세요 -->

## 📚 참고

[이진 탐색 & 매개 변수 탐색](https://velog.io/@guswns3371/%EC%9D%B4%EC%A7%84-%ED%83%90%EC%83%89-%EB%A7%A4%EA%B0%9C-%EB%B3%80%EC%88%98-%ED%83%90%EC%83%89)