### PR TITLE
[jeyoon] Programmers_연속 부분 수열 합의 개수

### DIFF
--- a/Programmers/연속_부분_수열_합의_개수/jeyoon.js
+++ b/Programmers/연속_부분_수열_합의_개수/jeyoon.js
@@ -1,0 +1,21 @@
+function solution(elements) {
+  const sumSet = new Set();
+  circularElements = elements.concat([...elements]); // 배열 이어붙여주기 (원형연결리스트 효과)
+  for (let winSize = 1; winSize <= elements.length; winSize++) {
+    let sum = 0;
+    for (let start = 0; start < elements.length; start++) {
+      if (start === 0) {
+        // 첫번째 반복에는 슬라이딩 윈도우 합 초기화 해 주기
+        for (let idx = start; idx < winSize; idx++)
+          sum += circularElements[idx];
+      } else {
+        // 이후 반복부터는 윈도우의 앞 원소를 빼 주고 윈도우 마지막 원소를 추가해주기
+        sum -= circularElements[start - 1];
+        sum += circularElements[start + winSize - 1];
+      }
+      sumSet.add(sum);
+    }
+  }
+
+  return sumSet.size;
+}


### PR DESCRIPTION
<!--

✅ 올리기 전 체크리스트

✔️ 한 문제에 대한 commit들만 올려져 있나요? (문제 별로 다른 PR을 올려주세요 ^_^)
✔️ 폴더 경로 확인! (문제사이트/문제이름(번호.문제명 OR 문제명(띄어쓰기는 모두 _로 치환)))
✔️ Assignees 추가했나요? (본인으로 추가!)
✔️ Label 추가했나요? (문제 사이트, 푼 언어)
✔️ 수고하셨습니다~!🥳

-->

## 🔗 문제 링크

https://school.programmers.co.kr/learn/courses/30/lessons/131701

<img width="50%" src="https://github.com/women-in-42-study/Algorithm/assets/57761286/8d8d2029-4203-4c28-b9f1-a2c74f62aec1"/>

위와 같은 원형 수열 elements가 순서대로 주어질 때, 원형 수열의 연속 부분 수열 합으로 만들 수 있는 수의 개수를 return 하도록 solution 함수를 완성하는 문제입니다.

## 🔮 풀이 아이디어

바쁘다는 핑계로 스터디를 만들어놓고도 문제를 안풀어서 너무 민망하네요,, 남은 7월동안 하루 한문제 페이스 꼭 유지해보도록 하겠습니다~~!!!!! 🔥💪

---

원형 연결리스트에서 부분 수열을 만들고, 그 부분수열의 원소들의 합의 종류를 구하는 문제였습니다!
원형 연결리스트를 구현해야 하나...? 하고 생각했었는데, 계속 돌면서 순회하는 문제가 아니라 단순히 끝 원소에서 첫번째 원소로 한번만 연결해주면 되는 문제였기에 concat 함수로 elements 배열 2개를 연결해준 circularElements 배열로 원형 연결리스트 효과를 내었습니다.

"연속된" 부분 수열의 "합" 이고 부분수열의 길이가 고정되어 있기 때문에 슬라이딩 윈도우 알고리즘을 이용하여 풀었습니다! (언젠가 어떤 분 PR에서 본 기억이 나서 쉽게 떠올릴 수 있었어요 🥳)
슬라이딩 윈도우 알고리즘에 대해서 간단히 정리하면 아래 그림과 같이 고정된 크기의 윈도우(고정된 길이의 범위)를 밀면서 초기 범위에서 빠지는 원소는 빼 주고, 추가되는 원소는 추가해주는 방식으로 진행되는 알고리즘입니다.
<img width="50%" src="https://github.com/women-in-42-study/Algorithm/assets/57761286/c650ca77-2dd9-45da-bc3c-793c4e715441"/>
이미 범위에 포함되어 있는 원소에 대해서는 추가적인 연산을 하지 않기 때문에 좀 더 효율적으로 구간합을 구할 수 있습니다.

## 📝 새로 공부한 내용

concat : https://developer.mozilla.org/ko/docs/Web/JavaScript/Reference/Global_Objects/Array/concat
배열이나 값들을 인자로 받아 기존 배열에 이어붙이고, 새로운 배열을 반환하는 함수입니다.
```js
const alpha = ['a', 'b', 'c'];
const numeric = [1, 2, 3];

alpha.concat(numeric);
// 결과: ['a', 'b', 'c', 1, 2, 3]
```

---

제 코드에 보면 아래처럼 var, let, const 키워드를 이용해서 circularElements를 미리 선언하지 않고도 선언하고 초기화한 부분이 있습니다!
```js
circularElements = elements.concat([...elements]); // 배열 이어붙여주기 (원형연결리스트 효과)
```
기존에는 circularElements 자리에 elements를 두고 기존 변수를 덮어씌우는 방법으로 코드를 짰기에 변수 선언 키워드를 두지 않았었는데요. 수정하면서 키워드를 넣는 것을 빼먹은 것이었습니다 😂
에러가 났었어야 할 것 같은데 정상적으로 잘 실행된것이 신기해서 찾아보니 non-strict mode를 사용할 경우 (따로 설정하지 않으면 기본적으로 자바스크립트는 non-strict mode에서 실행됩니다!) let, var, const 키워드를 빼고 변수를 선언할 경우 암시적인 전역 변수가 된다고 하네요............... let, var, const 키워드를 사용하는 이유가 변수 선언 목적이 아닌 scope 설정 목적이었다니 신기했습니다......... (이걸 아직도 모르고 있었네요 ㅋㅋㅋㅜㅜ)

## 📚 참고

<!-- 문제를 풀면서 참고했던 링크가 있다면 추가해주세요 -->