### PR TITLE
[seonjeon] BOJ_나이트의 이동

### DIFF
--- a/BOJ/7562.나이트의_이동/seonjeon.cpp
+++ b/BOJ/7562.나이트의_이동/seonjeon.cpp
@@ -1,0 +1,53 @@
+#include <iostream>
+#include <queue>
+
+using namespace std;
+
+int dx[] = {-2, -2, -1, -1, 1, 1, 2, 2};
+int dy[] = {-1, 1, -2, 2, -2, 2, -1, 1};
+
+int bfs(queue<pair<int, int> > queue, int destX, int destY, int lineLen) {
+    int answer  = 1;
+    int map[301][301] = {0};
+    map[queue.front().first][queue.front().second] = 1;
+    while (!queue.empty()) {
+        int qSize = queue.size();
+        for(int j = 0; j < qSize; j++) {
+            int x = queue.front().first;
+            int y = queue.front().second;
+            queue.pop();
+            for(int i = 0; i < 8; i++) {
+                int nx = x + dx[i];
+                int ny = y + dy[i];
+                if (nx < 0 || ny < 0 || nx >= lineLen || ny >= lineLen)
+                    continue;
+                if (nx == destX && ny == destY)
+                    return answer;
+                if (map[nx][ny] == 0) {
+                    map[nx][ny] = 1;
+                    queue.push(make_pair(nx, ny));
+                }
+            }
+        }
+        answer++;
+    }
+    return -1;
+}
+
+int main() {
+    int T, lineLen, x, y, ans;
+
+    cin >> T;
+    for(int i = 0; i < T; i++) {
+        cin >> lineLen >> x >> y;
+        queue<pair<int, int> > queue;
+        queue.push(make_pair(x, y));
+        cin >> x >> y;
+        if (queue.front().first == x && queue.front().second == y)
+            ans = 0;
+        else
+            ans = bfs(queue, x, y, lineLen);
+        cout << ans << "\n";
+    }
+
+}


### PR DESCRIPTION
<!--

✅ 올리기 전 체크리스트

✔️ 한 문제에 대한 commit들만 올려져 있나요? (문제 별로 다른 PR을 올려주세요 ^_^)
✔️ 폴더 경로 확인! (문제사이트/문제이름(번호.문제명 OR 문제명(띄어쓰기는 모두 _로 치환)))
✔️ Assignees 추가했나요? (본인으로 추가!)
✔️ Label 추가했나요? (문제 사이트, 푼 언어)
✔️ 수고하셨습니다~!🥳

-->

## 🔗 문제 링크

https://www.acmicpc.net/problem/7562

체스판에 시작 위치와 도착 위치가 주어질 때 나이트를 이용하여 최소 몇 번만에 도착할 수 있는지 출력하는 문제입니다.
테스트케이스 수와 각 테스트케이스의 체크판 크기, 시작 위치와 도착 위치가 주어집니다.
* 나이트는 직선으로 두 칸 이동 후 옆으로 한 칸 이동 가능합니다.


## 🔮 풀이 아이디어

최소 거리를 구하는 문제여서 너비우선탐색의 depth를 구했습니다.
시작 위치와 도착 위치가 같은 경우만 예외로 두었고
이동 방향 배열을 미리 나이트의 움짐임에 맞게 수정했습니다
`int dx[] = {-2, -2, -1, -1, 1, 1, 2, 2};`
`int dy[] = {-1, 1, -2, 2, -2, 2, -1, 1};`


## 📝 새로 공부한 내용

c++로 queue와 pair를 사용해볼 수 있었습니다.
이번에 depth를 구할 때 큐의 크기를 구해서 그 때의 크기만큼 반복문을 돌면 depth를 증가시키는 방법을 사용했는데
큐에 값을 넣을 때 map의 값을 증가시켜 도착 위치에서의 값을 결과로 쓰는 방법도 있다는 것도 알게됐습니다.


## 📚 참고

