### PR TITLE
[jeyoon] Programmers_[1차] 캐시

### DIFF
--- a/Programmers/[1차]_캐시/jeyoon.js
+++ b/Programmers/[1차]_캐시/jeyoon.js
@@ -1,0 +1,23 @@
+function solution(cacheSize, cities) {
+  let answer = 0;
+  let cache = [];
+  // 캐싱이 불가능한 경우의 예외처리
+  if (cacheSize === 0) return cities.length * 5;
+  cities.forEach((city) => {
+    const lowerCity = city.toLowerCase();
+    const ret = cache.indexOf(lowerCity);
+    // cache miss
+    if (ret === -1) {
+      cache.length >= cacheSize && cache.shift();
+      cache.push(lowerCity);
+      answer += 5;
+      return;
+    }
+    // cache hit
+    cache = cache.slice(0, ret).concat(cache.slice(ret + 1)); // ret을 제외한 나머지 원소들을 합쳐서 새로운 cache를 만들기!
+    // cache.splice(ret, 1); // ret에 해당하는 원소 하나만 지우기!
+    cache.push(lowerCity);
+    answer++;
+  });
+  return answer;
+}


### PR DESCRIPTION
<!--

✅ 올리기 전 체크리스트

✔️ 한 문제에 대한 commit들만 올려져 있나요? (문제 별로 다른 PR을 올려주세요 ^_^)
✔️ 폴더 경로 확인! (문제사이트/문제이름(번호.문제명 OR 문제명(띄어쓰기는 모두 _로 치환)))
✔️ Assignees 추가했나요? (본인으로 추가!)
✔️ Label 추가했나요? (문제 사이트, 푼 언어)
✔️ 수고하셨습니다~!🥳

-->

## 🔗 문제 링크

https://school.programmers.co.kr/learn/courses/30/lessons/17680

어피치에게 시달리는 제이지를 도와, DB 캐시를 적용할 때 캐시 크기에 따른 실행시간 측정 프로그램을 작성하시오.

조건
- 캐시 교체 알고리즘은 `LRU`(Least Recently Used)를 사용한다.
- `cache hit`일 경우 실행시간은 1이다.
- `cache miss`일 경우 실행시간은 5이다.

## 🔮 풀이 아이디어

이번에도 간단한 구현 문제였습니다!
캐시 교체 알고리즘인 LRU는 캐시에 저장되어있는 것들 중에서 가장 예전에 쓰였던 것을 제거하고 새로운 것을 저장하는 방식이기 때문에 (처음에는 아무 생각없이 가장 마지막으로 "저장되었던" 것을 제거하는 바람에 한번 틀렸습니다 😂) 계속해서 캐시를 업데이트 하는 방법으로 문제를 풀었습니당

cache miss인 경우에는 가장 마지막에 사용된 (최근에 사용된 것은 가장 뒤쪽으로 보내주었기 때문에 배열의 가장 앞 원소가 가장 마지막에 사용된 원소입니다.) 것을 제거해 준 뒤에 새로운 도시를 추가해주었고,
cache hit인 경우에는 해당 도시를 제외해서 다시 cache 배열을 만들어 준 뒤에 해당 도시를 다시 cache 배열의 가장 뒤에 넣어주는 방식으로 캐시를 업데이트 해 주었습니다.

## 📝 새로 공부한 내용

js 배열에는 erase라는 메소드가 없어서 한 원소를 콕 집어 지울 수 있는 방법이 없을 것이라 생각하고

```js
cache = cache.slice(0, ret).concat(cache.slice(ret + 1));
```

이렇게 ret이라는 인덱스의 원소를 없애기 위해서 ret을 기준으로 앞 배열과 뒷 배열을 새로 만들어서 연결한 배열을 새로 만드는 복잡한 방법을 썼는데요. 다른 분들의 코드를 보다가 splice 메소드를 이용한 방법이 있다는 것을 알게 되었습니다 😂
splice는 배열에서 원소를 제거하는 메소드이고 시작 지점과 그 시작 지점에서 몇개의 원소를 제거할지를 인자로 받습니다. 따라서

```js
cache.splice(ret, 1);
```

이런 식으로 하면 ret에 해당하는 원소 하나만 지울 수 있었습니다... splice 메소드 자체는 알고 있었는데 전달해야 하는 인자를 slice와 비슷하게 범위를 전달해야 하는 것으로 착각하고 있었어서 활용하지 못했네요..ㅎㅎㅜ

그리고 이 문제에서는 원소 중간에서 삽입하고 삭제해야 하는 작업이 많아서 사실은 map이나 set 같은 자료구조를 생각하고 있었는데 C++에서는 map이나 set 모두 삽입하게 되면 자동으로 오름차순 정렬이 되는 것으로 알고 있어서 막연하게 js도 자동정렬이 되겠거니 하고 사용하지 않았습니다. 근데 다른 분들 풀이에 map이 등장해서 다시 찾아보니 map과 set 모두 본래의 삽입 순서를 기억하고 있다고 하네요... 정말 생각지도 못했던 사실이라 놀랐습니다 ㅋㅋㅋ 

## 📚 참고

- https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/splice
- https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map
- https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set
